### PR TITLE
Remove hardcoded link name

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -55,7 +55,6 @@ struct statfs64 {
 }
 
 extern "C" {
-    #[link_name = "\u{1}_getfsstat$INODE64"]
     fn getfsstat(buf: *mut statfs64, bufsize: c_int, flags: c_int) -> c_int;
 }
 


### PR DESCRIPTION
Specifying this link name is broken on MacOS 12.5.1 with an ARM64 CPU, and not specifying the name at all just works. Not sure why it was originally needed in the first place.

https://github.com/Speedy37/mountpoints-rs/issues/6