### PR TITLE
macos aarch64 support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build AArch64
         if: matrix.os == 'macos-latest'
-        run: rustup target install aarch64-apple-darwin && cargo +aarch64-apple-darwin build --verbose
+        run: rustup target install aarch64-apple-darwin && cargo build --verbose --target=aarch64-apple-darwin
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Build AArch64
+        if: matrix.os == 'macos-latest'
+        run: cargo +aarch64-apple-darwin build --verbose
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build AArch64
         if: matrix.os == 'macos-latest'
-        run: rustup toolchain install aarch64-apple-darwin build && cargo +aarch64-apple-darwin build --verbose
+        run: rustup target install aarch64-apple-darwin && cargo +aarch64-apple-darwin build --verbose
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build AArch64
         if: matrix.os == 'macos-latest'
-        run: cargo +aarch64-apple-darwin build --verbose
+        run: rustup toolchain install aarch64-apple-darwin build && cargo +aarch64-apple-darwin build --verbose
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Build AArch64
-        if: matrix.os == 'macos-latest'
-        run: rustup target install aarch64-apple-darwin && cargo build --verbose --target=aarch64-apple-darwin
       - name: Build
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose -- --nocapture
+      - name: Build AArch64
+        if: matrix.os == 'macos-latest'
+        run: rustup target install aarch64-apple-darwin && cargo build --tests --verbose --target=aarch64-apple-darwin

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -55,7 +55,10 @@ struct statfs64 {
 }
 
 extern "C" {
-    #[link_name = "\u{1}_getfsstat$INODE64"]
+    #[cfg_attr(
+        all(target_os = "macos", not(target_arch = "aarch64")),
+        link_name = "getfsstat$INODE64"
+    )]
     fn getfsstat(buf: *mut statfs64, bufsize: c_int, flags: c_int) -> c_int;
 }
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -5,62 +5,7 @@ use std::os::raw::{c_char, c_int};
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 
-#[allow(non_camel_case_types)]
-type uid_t = u32;
-
-#[repr(C)]
-struct fsid_t {
-    val: [i32; 2],
-}
-
-const MFSTYPENAMELEN: usize = 16;
-const MAXPATHLEN: usize = 1024;
-const MNT_NOWAIT: c_int = 2;
-const MNT_RDONLY: u32 = 1;
-
-#[repr(C)]
-struct statfs64 {
-    /// fundamental file system block size
-    f_bsize: u32,
-    /// optimal transfer block size
-    f_iosize: i32,
-    /// total data blocks in file system
-    f_blocks: u64,
-    /// free blocks in fs
-    f_bfree: u64,
-    /// free blocks avail to non-superuser
-    f_bavail: u64,
-    /// total file nodes in file system
-    f_files: u64,
-    /// free file nodes in fs
-    f_ffree: u64,
-    /// file system id
-    f_fsid: fsid_t,
-    /// user that mounted the filesystem    
-    f_owner: uid_t,
-    /// type of filesystem
-    f_type: u32,
-    /// copy of mount exported flags
-    f_flags: u32,
-    /// fs sub-type (flavor)
-    f_fssubtype: u32,
-    /// fs type name
-    f_fstypename: [u8; MFSTYPENAMELEN],
-    /// directory on which mounted
-    f_mntonname: [u8; MAXPATHLEN],
-    /// mounted filesystem
-    f_mntfromname: [u8; MAXPATHLEN],
-    /// For future use  
-    f_reserved: [u32; 8],
-}
-
-extern "C" {
-    #[cfg_attr(
-        all(target_os = "macos", not(target_arch = "aarch64")),
-        link_name = "getfsstat$INODE64"
-    )]
-    fn getfsstat(buf: *mut statfs64, bufsize: c_int, flags: c_int) -> c_int;
-}
+const MNT_RDONLY: u32 = libc::MNT_RDONLY as u32;
 
 #[derive(Debug)]
 pub enum Error {
@@ -77,13 +22,13 @@ impl fmt::Display for Error {
     }
 }
 
-fn _mounts(mut cb: impl FnMut(&statfs64, PathBuf) -> Result<(), Error>) -> Result<(), Error> {
-    let mut n: i32 = unsafe { getfsstat(std::ptr::null_mut(), 0, MNT_NOWAIT) };
-    let mut mntbuf = Vec::<statfs64>::new();
+fn _mounts(mut cb: impl FnMut(&libc::statfs, PathBuf) -> Result<(), Error>) -> Result<(), Error> {
+    let mut n: i32 = unsafe { libc::getfsstat(std::ptr::null_mut(), 0, libc::MNT_NOWAIT) };
+    let mut mntbuf = Vec::<libc::statfs>::new();
     if n > 0 {
         mntbuf.resize_with(n as usize, || unsafe { std::mem::zeroed() });
-        let bufsize = mntbuf.len() * std::mem::size_of::<statfs64>();
-        n = unsafe { getfsstat(mntbuf.as_mut_ptr(), bufsize as c_int, MNT_NOWAIT) };
+        let bufsize = mntbuf.len() * std::mem::size_of::<libc::statfs>();
+        n = unsafe { libc::getfsstat(mntbuf.as_mut_ptr(), bufsize as c_int, libc::MNT_NOWAIT) };
         if n >= 0 {
             mntbuf.truncate(n as usize);
         }


### PR DESCRIPTION
- add ci for macos aarch64 build + link (ie. tests)
- migrate to using libc crate on macos

Fixes #6 